### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,12 +10,12 @@ MD_4017_KM	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin KEYWORD2
-read KEYWORD2
-setDebounceTime KEYWORD2
-setRepeatTime KEYWORD2
+begin	KEYWORD2
+read	KEYWORD2
+setDebounceTime	KEYWORD2
+setRepeatTime	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)
 #######################################
-KEY_NONE LITERAL1
+KEY_NONE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords